### PR TITLE
docs: clarify frontend setup (run npm in UI/frontend)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ _This notice should stay as the first item in the `CONTRIBUTING.md` file._
 ```bash
 # Clone the repo
 git clone https://github.com/amandewatnitrr/hacking-tutorial.git
-cd hacking-tutorial
+cd hacking-tutorial/UI/frontend
 
 # Install dependencies
 npm install


### PR DESCRIPTION
Update the Development Setup instructions in CONTRIBUTING.md to clarify that `npm install` and `npm run dev` must be executed inside `UI/frontend`, where the frontend's package.json resides.

Why:
Running the commands from the repository root as instructed results in "ENOENT: Could not read package.json" errors and blocks new contributors.

<img width="1080" height="195" alt="image" src="https://github.com/user-attachments/assets/b72e8ab0-101f-404b-90b4-2f1d5a286388" />


This change improves onboarding and prevents a common setup issue.