### PR TITLE
Fix(nav): Make mobile menu toggle functional (Closes #93)

### DIFF
--- a/UI/frontend/src/components/Navbar.css
+++ b/UI/frontend/src/components/Navbar.css
@@ -71,27 +71,84 @@
   color: var(--text-primary);
 }
 
+/* --- ADD THIS SECTION --- */
+/* Hamburger Button (Hidden on Desktop by default) */
+.mobile-menu-button {
+  display: none;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.5rem;
+  color: var(--text-primary);
+  z-index: 101; /* Keep it above the menu */
+}
+
+.mobile-menu-button svg {
+  width: 24px;
+  height: 24px;
+}
+/* --- END ADD --- */
+
+
 @media (max-width: 768px) {
   .navbar-container {
     padding: 1rem;
+    /* Ensure z-index allows button to be on top */
+    position: relative;
+    z-index: 1001;
   }
 
   .navbar-brand {
     font-size: 1.2rem;
   }
 
+  /* --- MODIFY THIS SECTION --- */
+
   .navbar-links {
+    /* Hide menu by default */
+    display: none;
+
+    /* Style as a dropdown */
+    flex-direction: column;
+    position: absolute;
+    top: 65px; /* Adjust to be below your navbar */
+    right: 1rem;
+    width: 90%;
+    max-width: 320px;
+
+    /* Appearance */
+    background-color: var(--bg-secondary);
+    border: 1px solid var(--accent-green);
+    border-radius: 8px;
+    padding: 1rem;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+    z-index: 1000;
+    
+    /* Overrides from desktop */
     gap: 0.5rem;
+    align-items: flex-start;
+  }
+
+  /* This is the magic! Show the menu when it has the .active class */
+  .navbar-links.active {
+    display: flex;
   }
 
   .nav-link {
-    padding: 0.4rem 0.8rem;
-    font-size: 0.9rem;
+    padding: 0.8rem 0.5rem;
+    font-size: 1rem;
+    width: 100%; /* Make links fill the dropdown */
   }
+
+  /* Show the hamburger button on mobile */
+  .mobile-menu-button {
+    display: block;
+  }
+  
+  /* --- END MODIFY --- */
 
   .bg-transparent {
     background-color: transparent;
     color: var(--text-primary);
   }
-
 }

--- a/UI/frontend/src/components/Navbar.jsx
+++ b/UI/frontend/src/components/Navbar.jsx
@@ -1,8 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react'; // 1. Import useState
 import { Link } from 'react-router-dom';
 import './Navbar.css';
 
 const Navbar = () => {
+  // 2. Add state for the menu toggle
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
   return (
     <nav className="navbar">
       <div className="navbar-container">
@@ -11,20 +14,21 @@ const Navbar = () => {
           <span className="brand-text">HackLearn</span>
         </Link>
 
-        <div className="navbar-links">
-            <button
-              type="button"
-              className="nav-link bg-transparent"
-              onClick={() => {
-                try {
-                  window.dispatchEvent(new CustomEvent('open-sidebar'));
-                } catch { }
-              }}
-              aria-label="Open lessons sidebar"
-              title="Lessons"
-            >
-              Lessons
-            </button>
+        {/* 3. Add the 'active' class conditionally */}
+        <div className={`navbar-links ${isMenuOpen ? 'active' : ''}`}>
+          <button
+            type="button"
+            className="nav-link bg-transparent"
+            onClick={() => {
+              try {
+                window.dispatchEvent(new CustomEvent('open-sidebar'));
+              } catch { }
+            }}
+            aria-label="Open lessons sidebar"
+            title="Lessons"
+          >
+            Lessons
+          </button>
           <Link to="/" className="nav-link">Home</Link>
           <a
             href="https://github.com/amandewatnitrr/hacking-tutorial.git"
@@ -38,6 +42,19 @@ const Navbar = () => {
             GitHub
           </a>
         </div>
+
+        {/* 4. Add the hamburger menu button */}
+        <button
+          className="mobile-menu-button"
+          onClick={() => setIsMenuOpen(!isMenuOpen)} // This toggles the state
+          aria-label="Toggle navigation menu"
+        >
+          {/* You can swap this SVG for a 'close' icon when open */}
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+          </svg>
+        </button>
+
       </div>
     </nav>
   );


### PR DESCRIPTION
## Description
This PR fixes issue #93 by making the mobile navigation menu functional.

## Changes Made
- Added `useState` to `Navbar.jsx` to track the menu's open/closed state.
- Added a hamburger button (`.mobile-menu-button`) that toggles this state on click.
- Updated `Navbar.css` to hide the `.navbar-links` on mobile by default.
- Added styles to show the `.navbar-links` as a dropdown when the `.active` class is present.

## How to Test
1. Run the app and shrink the browser window to a mobile width.
2. Click the hamburger icon.
3. **Verify:** The navigation menu appears.
4. Click the icon again.
5. **Verify:** The navigation menu disappears.