### PR TITLE
fix(sidebar): prevent sidebar header from sliding under navbar

### DIFF
--- a/UI/frontend/src/components/Sidebar.css
+++ b/UI/frontend/src/components/Sidebar.css
@@ -4,7 +4,7 @@
 
 .hl-sidebar__panel {
   position: sticky;
-  top: 0;
+  top: 64px;
   height: calc(100vh - 64px);
   overflow: auto;
   width: 300px;
@@ -146,9 +146,9 @@
   .hl-sidebar__panel {
     position: fixed;
     left: 0;
-    top: 0;
+    top: 64px;
     bottom: 0;
-    height: 100vh;
+    height: calc(100vh - 64px);
     pointer-events: auto;
     transform: translateX(-100%);
     transition: transform 220ms ease-in-out;


### PR DESCRIPTION
It looks fine at the top:
<img width="250" height="300" alt="image" src="https://github.com/user-attachments/assets/92c77cdf-924a-4125-8ecb-2d35d2d9df1a" />

However, after scrolling down a bit:
<img width="250" height="350" alt="image" src="https://github.com/user-attachments/assets/99b3be62-27a1-48a4-a7a5-7c453edf5742" />

The sidebar header disappears, leaving you unable to untoggle the sidebar since the untoggler is inside the header.
This happens because the sidebar header slides under the navbar.

I made sure to fix it for both desktop and mobile views:
<img width="220" height="450" alt="image" src="https://github.com/user-attachments/assets/cce806a5-7968-4cfc-8c06-3f1f12528bef" />

Fix
- changed from top: 0 to top: 64px to .hl-sidebar__panel
- Applied the same fix in @media (max-width: 1024px)
- Changed height: 100vh to height: calc(100vh - 64px) in the mobile layout to allow scrolling through all content (same behavior as desktop)

Result
- Sidebar header stays visible below the navbar
- Sidebar content scrolls correctly on both desktop and mobile
- Untoggler button remains accessible at all times